### PR TITLE
Add persistent SQLite storage for activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.log
 *.sql
 *.sqlite
+data.db
 
 # OS generated files #
 ######################

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+SQLAlchemy

--- a/src/app.py
+++ b/src/app.py
@@ -5,77 +5,117 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import RedirectResponse
-import os
-from pathlib import Path
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
+
+import db
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
 # Mount the static files directory
-current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app.mount("/static", StaticFiles(directory="./static"), name="static")
 
-# In-memory activity database
-activities = {
+
+# Default activities to seed when the database is empty
+DEFAULT_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
     },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
     },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
     },
     "Basketball Team": {
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
     },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
     },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
     },
     "Math Club": {
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
     },
     "Debate Team": {
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
 }
+
+
+def _serialize_activity(activity: db.Activity) -> dict:
+    return {
+        "description": activity.description,
+        "schedule": activity.schedule,
+        "max_participants": activity.max_participants,
+        "participants": [p.email for p in activity.participants],
+    }
+
+
+def _seed_activities(db_session: Session) -> None:
+    """Seed the database with default activities if empty."""
+    existing = db_session.query(db.Activity).count()
+    if existing > 0:
+        return
+
+    for name, details in DEFAULT_ACTIVITIES.items():
+        activity = db.Activity(
+            name=name,
+            description=details["description"],
+            schedule=details["schedule"],
+            max_participants=details["max_participants"],
+        )
+        db_session.add(activity)
+        db_session.flush()  # get id
+
+        for email in details["participants"]:
+            participant = db.Participant(email=email, activity=activity)
+            db_session.add(participant)
+
+    db_session.commit()
+
+
+@app.on_event("startup")
+def on_startup():
+    db.init_db()
+    # Seed initial activities if the database is new/empty
+    with db.SessionLocal() as session:
+        _seed_activities(session)
 
 
 @app.get("/")
@@ -84,49 +124,43 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(db_session: Session = Depends(db.get_db)):
+    activities = db_session.query(db.Activity).all()
+    return {activity.name: _serialize_activity(activity) for activity in activities}
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, db_session: Session = Depends(db.get_db)):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = db_session.query(db.Activity).filter_by(name=activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    if any(p.email == email for p in activity.participants):
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    if len(activity.participants) >= activity.max_participants:
+        raise HTTPException(status_code=400, detail="Activity is already full")
 
-    # Add student
-    activity["participants"].append(email)
+    participant = db.Participant(email=email, activity=activity)
+    db_session.add(participant)
+    db_session.commit()
+
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, db_session: Session = Depends(db.get_db)):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = db_session.query(db.Activity).filter_by(name=activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    participant = next((p for p in activity.participants if p.email == email), None)
+    if not participant:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+    db_session.delete(participant)
+    db_session.commit()
 
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from sqlalchemy import (Column, ForeignKey, Integer, String, UniqueConstraint,
+                        create_engine)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, sessionmaker
+
+# Use a file-based SQLite database in the repository root.
+BASE_DIR = Path(__file__).resolve().parent.parent
+DB_PATH = BASE_DIR / "data.db"
+DATABASE_URL = f"sqlite:///{DB_PATH}"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    description = Column(String, nullable=False)
+    schedule = Column(String, nullable=False)
+    max_participants = Column(Integer, nullable=False)
+
+    participants = relationship(
+        "Participant",
+        back_populates="activity",
+        cascade="all, delete-orphan",
+        lazy="joined",
+    )
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, nullable=False)
+    activity_id = Column(Integer, ForeignKey("activities.id"), nullable=False)
+
+    activity = relationship("Activity", back_populates="participants")
+
+    __table_args__ = (UniqueConstraint("activity_id", "email", name="uq_activity_email"),)
+
+
+def init_db():
+    """Create database tables.
+
+    This is safe to call multiple times.
+    """
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    """Yield a SQLAlchemy session (dependency)."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
This PR replaces the in-memory activities dict with a SQLite database backed by SQLAlchemy. It includes seeding of default activities and supports signups/unregistering with persistence across restarts.